### PR TITLE
Dataset manager edits

### DIFF
--- a/core/dataset_manager.py
+++ b/core/dataset_manager.py
@@ -12,7 +12,6 @@ import tests.context
 import numpy as np
 import pandas as pd
 
-#import core.utils.context
 from core.configuration import ConfigurationManager
 
 

--- a/core/dataset_manager.py
+++ b/core/dataset_manager.py
@@ -132,8 +132,10 @@ class DatasetManager():
             timestamp = str(datetime.datetime.now())
             r_string = random_string(5)
             new_name = timestamp + r_string
-            transformed_data.to_csv(os.path.join(new_folder, new_name + '.csv'),
-                                    index=False)
+            transformed_data.to_csv(
+                os.path.join(new_folder, new_name + '.csv'),
+                index=False
+            )
 
         assert os.path.isdir(os.path.join(self.rfp, 'transformed'))
 

--- a/core/dataset_manager.py
+++ b/core/dataset_manager.py
@@ -4,9 +4,15 @@ import datetime
 import string
 import random
 import os
+import string
+import random
+import os
 import tests.context
+
 import numpy as np
 import pandas as pd
+
+#import core.utils.context
 from core.configuration import ConfigurationManager
 
 
@@ -77,8 +83,10 @@ class DatasetManager():
             dataset2.csv
             md_dataset2.csv
         transformed/
-            06/10/16sgf.csv
-            06/10/16mlf.csv
+            dataset1/
+                06/10/16sgf.csv
+            dataset2/
+                06/10/16mlf.csv
 
     """
 
@@ -118,11 +126,14 @@ class DatasetManager():
         #'transformed'. Names in this folder are generated using a timestamp
         #joined with some random characters.
         for name,data in raw_data.items():
+            new_folder = os.path.join(self.tfp, name)
+            if not os.path.exists(new_folder):
+                os.makedirs(new_folder)
             transformed_data = transform_function(data)
             timestamp = str(datetime.datetime.now())
             r_string = random_string(5)
             new_name = timestamp + r_string
-            transformed_data.to_csv(os.path.join(self.tfp, new_name + '.csv'),
+            transformed_data.to_csv(os.path.join(new_folder, new_name + '.csv'),
                                     index=False)
 
         assert os.path.isdir(os.path.join(self.rfp, 'transformed'))
@@ -163,10 +174,12 @@ class DatasetManager():
 
         if self.tfp:
             transform_dict = {}
-            for file in os.listdir(self.tfp):
-                if file[-4:] == '.csv':
-                    data = pd.read_csv(os.path.join(self.tfp, file))
-                    transform_dict[file] = data
+            for folder in os.listdir(self.tfp):
+                folder_path = os.path.join(self.tfp, folder)
+                for file in os.listdir(folder_path):
+                    if file[-4:] == '.csv':
+                        data = pd.read_csv(os.path.join(folder_path, file))
+                        transform_dict[file] = data
             return transform_dict
         else:
             raise TransformedNotFoundError()


### PR DESCRIPTION
Really simple pull request. Updated Dataset Manager to copy over directories into transformed folder. File directory would look something like this:

```
main/
        dataset1/
            dataset1.csv
            md_dataset1.csv
        dataset2/
            dataset2.csv
            md_dataset2.csv
        transformed/
            dataset1/
                06/10/16sgf.csv
            dataset2/
                06/10/16mlf.csv
```

Tl;dr one can now view the transformed datasets of the corresponding folders in the original data directory.