### PR TITLE
(Naive) DatasetClassifier + DBClient + DatasetManager edits

### DIFF
--- a/core/database_config.json
+++ b/core/database_config.json
@@ -1,0 +1,8 @@
+{
+    "user": "datashark",
+    "pw": "datashark",
+    "db": "datasharkdb",
+    "host": "datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com",
+    "port": "5432",
+    "table_name": "category_labels"
+}

--- a/core/dataset_classifier.py
+++ b/core/dataset_classifier.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+
+class DatasetClassifier(object):
+	def __init__(self, label):
+		self.label = label
+
+	def classify_dataset(self):
+		if not self.label:
+			raise Exception('Classifier is not working at this time.')
+		return self.label

--- a/core/dataset_classifier.py
+++ b/core/dataset_classifier.py
@@ -1,11 +1,19 @@
 import pandas as pd
 
+from core.db_client import DBClient
+
 
 class DatasetClassifier(object):
-	def __init__(self, label):
+	def __init__(self, label=None):
 		self.label = label
+		self.db_client = DBClient()
 
-	def classify_dataset(self):
+	def _classify_dataset(self):
 		if not self.label:
 			raise Exception('Classifier is not working at this time.')
 		return self.label
+
+	def label_dataset(self, name):
+		label = self._classify_dataset()
+		self.db_client.add_labels([name], [label])
+

--- a/core/dataset_manager.py
+++ b/core/dataset_manager.py
@@ -159,7 +159,7 @@ class DatasetManager():
                 if file[:2] != 'md':
                     file_path = os.path.join(folder_path, file)
                     dataset = pd.read_csv(file_path)
-                    raw_dict[file] = dataset
+                    raw_dict[file[:-4]] = dataset
         return raw_dict
 
     def get_transformed_data(self):

--- a/core/db_client.py
+++ b/core/db_client.py
@@ -1,0 +1,47 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+import json
+import pandas as pd
+
+
+class DBClient(object):
+
+	def __init__(self, config_filepath = 'database_config.json'):
+		"""
+		Set up DBClient with corresponding database credentials
+		"""
+		app = Flask(__name__)
+		with open(config_filepath) as f:
+			POSTGRES = json.load(f)
+		app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://%(user)s:%(pw)s@%(host)s:%(port)s/%(db)s' % POSTGRES
+		app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+		self.db = SQLAlchemy(app)
+		self.table_name = POSTGRES['table_name']
+		self._reset()
+
+	def get_labels(self):
+		"""
+		Get category_labels table
+		"""
+		return pd.read_sql_query("select * from {table_name}".format(table_name=self.table_name), self.db.engine)
+
+	def add_labels(self, data_providers, categories):
+		"""
+		Append category labels to the category_labels table, where categories[i] corresponds to the labeled category
+		for data_providers[i]
+		"""
+		rows = {'data_provider': data_providers, 'category': categories} 
+		label = pd.DataFrame(data=rows)
+		label.to_sql(name=self.table_name, con=self.db.engine, if_exists='append', index=False)
+
+	def get_data_providers_with_category(self, category):
+		"""
+		Get a list of data providers with the given category.
+		"""
+		return pd.read_sql_query("select * from {table_name} where category = '{category}'"
+			.format(category=category, table_name=self.table_name), self.db.engine)
+
+	def _reset(self):
+		label = pd.DataFrame(columns=['data_provider', 'category'])
+		label.to_sql(name=self.table_name, con=self.db.engine, if_exists='replace', index=False)
+		

--- a/core/db_client.py
+++ b/core/db_client.py
@@ -17,7 +17,6 @@ class DBClient(object):
 		app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 		self.db = SQLAlchemy(app)
 		self.table_name = POSTGRES['table_name']
-		self._reset()
 
 	def get_labels(self):
 		"""

--- a/core/db_client.py
+++ b/core/db_client.py
@@ -41,7 +41,7 @@ class DBClient(object):
 		return pd.read_sql_query("select * from {table_name} where category = '{category}'"
 			.format(category=category, table_name=self.table_name), self.db.engine)
 
-	def _reset(self):
+	def reset(self):
 		label = pd.DataFrame(columns=['data_provider', 'category'])
 		label.to_sql(name=self.table_name, con=self.db.engine, if_exists='replace', index=False)
 		

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ blockchain==1.4.4
 asposebarcode==1.0.0
 base58==0.2.4
 psycopg2==2.7.3
+flask==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ filelock==3.0.4
 blockchain==1.4.4
 asposebarcode==1.0.0
 base58==0.2.4
+psycopg2==2.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ asposebarcode==1.0.0
 base58==0.2.4
 psycopg2==2.7.3
 flask==0.11.1
+Flask_SQLAlchemy==2.3.1

--- a/tests/artifacts/db_client/database_config.json
+++ b/tests/artifacts/db_client/database_config.json
@@ -1,0 +1,8 @@
+{
+    "user": "datashark",
+    "pw": "datashark",
+    "db": "datasharkdb",
+    "host": "datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com",
+    "port": "5432",
+    "table_name": "category_labels"
+}

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -30,8 +30,8 @@ def same_raw_data_test(dsm, expected_test1_raw, expected_test2_raw):
     Check get_raw_data actually returns the data in this directory
     '''
     raw_data = dsm.get_raw_data()
-    actual_test1_raw = raw_data['test1.csv']
-    actual_test2_raw = raw_data['test2.csv']
+    actual_test1_raw = raw_data['test1']
+    actual_test2_raw = raw_data['test2']
     assert expected_test1_raw.equals(actual_test1_raw)
     assert expected_test2_raw.equals(actual_test2_raw)
 

--- a/tests/test_dbclient.py
+++ b/tests/test_dbclient.py
@@ -25,10 +25,10 @@ def check_get_data_providers_with_category(db_client):
 	assert list(actual['category']) == ['social_media']
 
 def test_end_to_end(db_client):
-	db_client._reset()
+	db_client.reset()
 	check_empty_category_labels(db_client)
 	db_client.add_labels(['Facebook Profile Data'], ['social_media'])
 	check_add_works(db_client)
 	db_client.add_labels(['Fitbit Calories Burned'], ['fitness'])
 	check_get_data_providers_with_category(db_client)
-	db_client._reset()
+	db_client.reset()

--- a/tests/test_dbclient.py
+++ b/tests/test_dbclient.py
@@ -1,0 +1,34 @@
+import os
+import tests.context
+import psycopg2
+import pytest
+import pandas as pd
+from core.db_client import DBClient
+
+@pytest.fixture
+def db_client():
+	return DBClient(config_filepath='tests/artifacts/db_client/database_config.json')
+
+def check_empty_category_labels(db_client):
+	expected = pd.DataFrame(columns=['data_provider', 'category'])
+	actual = db_client.get_labels()
+	assert expected.equals(actual)
+
+def check_add_works(db_client):
+	actual = db_client.get_labels()
+	assert list(actual['data_provider']) == ['Facebook Profile Data']
+	assert list(actual['category']) == ['social_media']
+
+def check_get_data_providers_with_category(db_client):
+	actual = db_client.get_data_providers_with_category('social_media')
+	assert list(actual['data_provider']) == ['Facebook Profile Data']
+	assert list(actual['category']) == ['social_media']
+
+def test_end_to_end(db_client):
+	db_client._reset()
+	check_empty_category_labels(db_client)
+	db_client.add_labels(['Facebook Profile Data'], ['social_media'])
+	check_add_works(db_client)
+	db_client.add_labels(['Fitbit Calories Burned'], ['fitness'])
+	check_get_data_providers_with_category(db_client)
+	db_client._reset()


### PR DESCRIPTION
3 major changes: 

**(Naive) DatasetClassifier**: 
- Sets up framework for what classification will look like when we actually have a trained classifier
- For now, can be used to manually add labels to datasets (or just use DB client, TBD)
- Didn't write tests since it's not the long term option and the main functionality (posting to DB) is tested under DBClient
- Eventually will be called by DatasetManager after transform is completed

**DBClient**
- Label datasets and retrieve datasets with corresponding category
- Needed here so that DL2 Notebook can retrieve labels
- Unsure whether DL2 Notebook will use this DBClient (through Virtual Worker instance of UNIX Service) or have its own instance, TBD
- Will most likely replace RDS DB with DynamoDB for performance reasons, but I'll figure that out after MVP

**DatasetManager**
- Updated file directories so that dataset folders in transformed folder don't have `.csv` appended to them.

Roast away :)