### PR TITLE
Fix scheduler bug

### DIFF
--- a/core/questions.csv
+++ b/core/questions.csv
@@ -3,3 +3,4 @@ Where is the dataset path?,GENERAL,dataset_path,datasets/mnist
 How many runners should the scheduler manage?,SCHEDULER,num_runners,4
 How often should the scheduler run in minutes?,SCHEDULER,frequency_in_mins,1
 Where is the weights directory?,RUNNER,weights_directory,weights
+What is the max number of times a job should run?,SCHEDULER,max_tries,3

--- a/core/runner.py
+++ b/core/runner.py
@@ -106,7 +106,6 @@ class DMLRunner(object):
             print(e)
         self.current_job = None
         logging.info("Finished running job!")
-        print(results)
         return results # Returning is only for debugging purposes.
 
     def _train(self, serialized_model, model_type, initial_weights, hyperparams,

--- a/core/runner.py
+++ b/core/runner.py
@@ -51,17 +51,22 @@ class DMLRunner(object):
             'DMLJob type ({0}) is not valid'.format(job.job_type)
         logging.info("Running job (type: {0})...".format(job.job_type))
         if job.job_type == 'train':
-            new_weights, omega, train_stats = self._train(
-                job.serialized_model,
-                job.model_type,
-                job.weights,
-                job.hyperparams,
-                job.labeler
-            )
-            # TODO: Send the (new_weights_in_bytes, omega) to the aggregator
-            # through P2P.
-            print(train_stats)
-            return_obj = new_weights, omega, train_stats
+            try:
+                new_weights, omega, train_stats = self._train(
+                    job.serialized_model,
+                    job.model_type,
+                    job.weights,
+                    job.hyperparams,
+                    job.labeler
+                )
+                # TODO: Send the (new_weights_in_bytes, omega) to the aggregator
+                # through P2P.
+                print(train_stats)
+                return_obj = {
+                    "new_weights": new_weights,
+                    "omega": omega, 
+                    "train_stats": train_stats
+                }
         elif job.job_type == 'validate':
             val_stats = self._validate(
                  job.serialized_model,
@@ -76,6 +81,9 @@ class DMLRunner(object):
             # This has been assigned to Neelesh ^
             print(val_stats)
             return_obj = val_stats
+            return_obj = {
+                "val_stats": val_stats,
+            }
         elif job.job_type == 'initialize':
             # NOTE: This shouldn't be used in BETA/PROD right now, only DEV!!!
             initial_weights = self._initialize_model(
@@ -86,7 +94,9 @@ class DMLRunner(object):
             # TODO: Send (weights_in_bytes) to all nodes/aggregator/developer
             # through P2P.
             #print(initial_weights)
-            return_obj = initial_weights
+            return_obj = {
+                "initial_weights": initial_weights,
+            }
         self.current_job = None
         logging.info("Finished running job!")
         return return_obj # Returning is only for debugging purposes.

--- a/core/runner.py
+++ b/core/runner.py
@@ -50,52 +50,61 @@ class DMLRunner(object):
         assert job.job_type in ['train', 'validate', 'initialize'], \
             'DMLJob type ({0}) is not valid'.format(job.job_type)
         logging.info("Running job (type: {0})...".format(job.job_type))
-        if job.job_type == 'train':
-            try:
-                new_weights, omega, train_stats = self._train(
-                    job.serialized_model,
-                    job.model_type,
-                    job.weights,
-                    job.hyperparams,
-                    job.labeler
+        try:
+            if job.job_type == 'train':
+                try:
+                    new_weights, omega, train_stats = self._train(
+                        job.serialized_model,
+                        job.model_type,
+                        job.weights,
+                        job.hyperparams,
+                        job.labeler
+                    )
+                    # TODO: Send the (new_weights_in_bytes, omega) to the aggregator
+                    # through P2P.
+                    print(train_stats)
+                    return_obj = {
+                        "new_weights": new_weights,
+                        "omega": omega, 
+                        "train_stats": train_stats,
+                        "successful": True
+                    }
+            elif job.job_type == 'validate':
+                val_stats = self._validate(
+                     job.serialized_model,
+                     job.model_type,
+                     job.weights,
+                     job.hyperparams,
+                     job.labeler
                 )
-                # TODO: Send the (new_weights_in_bytes, omega) to the aggregator
-                # through P2P.
-                print(train_stats)
-                return_obj = {
-                    "new_weights": new_weights,
-                    "omega": omega, 
-                    "train_stats": train_stats
-                }
-        elif job.job_type == 'validate':
-            val_stats = self._validate(
-                 job.serialized_model,
-                 job.model_type,
-                 job.weights,
-                 job.hyperparams,
-                 job.labeler
-            )
 
-            # TODO: Send the results to the developer through P2P (maybe).
-            # How are we getting this metadata (val_stats) back to the user?
-            # This has been assigned to Neelesh ^
-            print(val_stats)
-            return_obj = val_stats
+                # TODO: Send the results to the developer through P2P (maybe).
+                # How are we getting this metadata (val_stats) back to the user?
+                # This has been assigned to Neelesh ^
+                print(val_stats)
+                return_obj = val_stats
+                return_obj = {
+                    "val_stats": val_stats,
+                    "successful": True
+                }
+            elif job.job_type == 'initialize':
+                # NOTE: This shouldn't be used in BETA/PROD right now, only DEV!!!
+                initial_weights = self._initialize_model(
+                    job.serialized_model,
+                    job.model_type
+                )
+                weights_in_bytes = serialize_weights(initial_weights)
+                # TODO: Send (weights_in_bytes) to all nodes/aggregator/developer
+                # through P2P.
+                #print(initial_weights)
+                return_obj = {
+                    "initial_weights": initial_weights,
+                    "successful": True
+                }
+        except Exception as e:
             return_obj = {
-                "val_stats": val_stats,
-            }
-        elif job.job_type == 'initialize':
-            # NOTE: This shouldn't be used in BETA/PROD right now, only DEV!!!
-            initial_weights = self._initialize_model(
-                job.serialized_model,
-                job.model_type
-            )
-            weights_in_bytes = serialize_weights(initial_weights)
-            # TODO: Send (weights_in_bytes) to all nodes/aggregator/developer
-            # through P2P.
-            #print(initial_weights)
-            return_obj = {
-                "initial_weights": initial_weights,
+                "successful": False,
+                "error_message": e
             }
         self.current_job = None
         logging.info("Finished running job!")

--- a/core/runner.py
+++ b/core/runner.py
@@ -62,10 +62,8 @@ class DMLRunner(object):
                     # TODO: Send the (new_weights_in_bytes, omega) to the aggregator
                     # through P2P.
                     print(train_stats)
-                    return_obj = {
-                        "new_weights": new_weights,
-                        "omega": omega, 
-                        "train_stats": train_stats,
+                    results = {
+                        "return_obj": (new_weights, omega, train_stats),
                         "successful": True
                     }
             elif job.job_type == 'validate':
@@ -82,8 +80,8 @@ class DMLRunner(object):
                 # This has been assigned to Neelesh ^
                 print(val_stats)
                 return_obj = val_stats
-                return_obj = {
-                    "val_stats": val_stats,
+                results = {
+                    "return_obj": val_stats,
                     "successful": True
                 }
             elif job.job_type == 'initialize':
@@ -96,18 +94,20 @@ class DMLRunner(object):
                 # TODO: Send (weights_in_bytes) to all nodes/aggregator/developer
                 # through P2P.
                 #print(initial_weights)
-                return_obj = {
-                    "initial_weights": initial_weights,
+                results = {
+                    "return_obj": initial_weights,
                     "successful": True
                 }
         except Exception as e:
-            return_obj = {
+            results = {
                 "successful": False,
                 "error_message": e
             }
+            print(e)
         self.current_job = None
         logging.info("Finished running job!")
-        return return_obj # Returning is only for debugging purposes.
+        print(results)
+        return results # Returning is only for debugging purposes.
 
     def _train(self, serialized_model, model_type, initial_weights, hyperparams,
         labeler):

--- a/core/runner.py
+++ b/core/runner.py
@@ -52,7 +52,6 @@ class DMLRunner(object):
         logging.info("Running job (type: {0})...".format(job.job_type))
         try:
             if job.job_type == 'train':
-                try:
                     new_weights, omega, train_stats = self._train(
                         job.serialized_model,
                         job.model_type,

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -39,6 +39,7 @@ class DMLScheduler(object):
 		self.dataset_path = config.get("GENERAL", "dataset_path")
 		self.frequency_in_mins = config.getint("SCHEDULER", "frequency_in_mins")
 		self.num_runners = config.getint("SCHEDULER", "num_runners")
+		self.max_tries = config.getint("SCHEDULER", "max_tries")
 
 		self.pool = Pool(processes=self.num_runners)
 		self.runners = [DMLRunner(config_manager) for _ in range(self.num_runners)]
@@ -112,7 +113,7 @@ class DMLScheduler(object):
 						#Still has tries remaining, so put back in queue
 						self.add_job(job_to_run)
 					else:
-						#Record error, ignore failed job
+						#Log error, ignore failed job
 						logging.error(finished_job_results['error'])
 						self.current_jobs[i] = None
 
@@ -121,7 +122,7 @@ class DMLScheduler(object):
 			if self.queue:
 				# If there's something to be scheduled...
 				job_to_run = self.queue.popleft()
-				job_to_run.num_tries_left = 3
+				job_to_run.num_tries_left = self.max_tries
 				# self.current_jobs[i] = runner.run_job(job_to_run)
 				self.current_jobs[i] = self.pool.apply_async(
 					runner.run_job,

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -100,6 +100,7 @@ class DMLScheduler(object):
 				finished_job_results = self.current_jobs[i].get()
 				if finished_job_results['successful']:
 					# If the job finished successfully...
+					finished_job = finished_job_results['return_obj']
 					self.processed.append(finished_job)
 					self.history.append(finished_job)
 					self.current_jobs[i] = None

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -11,131 +11,131 @@ from core.configuration import ConfigurationManager
 
 
 logging.basicConfig(level=logging.DEBUG,
-                    format='[Scheduler] %(asctime)s %(levelname)s %(message)s')
+					format='[Scheduler] %(asctime)s %(levelname)s %(message)s')
 
 class DMLScheduler(object):
-    """
-    DML Scheduler
+	"""
+	DML Scheduler
 
-    This class schedules and manages the execution of DMLJobs using the
-    DMLRunner.
+	This class schedules and manages the execution of DMLJobs using the
+	DMLRunner.
 
-    NOTE: Supports a multithreaded environment using multiprocessing.
-    NOTE2: Only supports one dataset type.
+	NOTE: Supports a multithreaded environment using multiprocessing.
+	NOTE2: Only supports one dataset type.
 
-    """
+	"""
 
-    def __init__(self, config_manager):
-        """
-        Initializes the instance.
-        """
-        logging.info("Setting up scheduler...")
-        self.queue = deque()
-        self.event = Event()
-        self.processed = []
-        self.history = []
+	def __init__(self, config_manager):
+		"""
+		Initializes the instance.
+		"""
+		logging.info("Setting up scheduler...")
+		self.queue = deque()
+		self.event = Event()
+		self.processed = []
+		self.history = []
 
-        config = config_manager.get_config()
-        self.dataset_path = config.get("GENERAL", "dataset_path")
-        self.frequency_in_mins = config.getint("SCHEDULER", "frequency_in_mins")
-        self.num_runners = config.getint("SCHEDULER", "num_runners")
+		config = config_manager.get_config()
+		self.dataset_path = config.get("GENERAL", "dataset_path")
+		self.frequency_in_mins = config.getint("SCHEDULER", "frequency_in_mins")
+		self.num_runners = config.getint("SCHEDULER", "num_runners")
 
-        self.pool = Pool(processes=self.num_runners)
-        self.runners = [DMLRunner(config_manager) for _ in range(self.num_runners)]
-        self.current_jobs = [None for _ in range(self.num_runners)]
-        logging.info("Scheduler is set up!")
+		self.pool = Pool(processes=self.num_runners)
+		self.runners = [DMLRunner(config_manager) for _ in range(self.num_runners)]
+		self.current_jobs = [None for _ in range(self.num_runners)]
+		logging.info("Scheduler is set up!")
 
-    def add_job(self, dml_job):
-        """
-        Add a job to the queue.
-        """
-        assert type(dml_job) is DMLJob, "Job is not of type DMLJob."
-        logging.info("Scheduling job...")
-        self.queue.append(dml_job)
+	def add_job(self, dml_job):
+		"""
+		Add a job to the queue.
+		"""
+		assert type(dml_job) is DMLJob, "Job is not of type DMLJob."
+		logging.info("Scheduling job...")
+		self.queue.append(dml_job)
 
-    def start_cron(self, period_in_mins=None):
-        """
-        CRON job to run next jobs on runners, if applicable. Runs asynchronously.
-        """
-        if not period_in_mins:
-            period_in_mins = self.frequency_in_mins
-        logging.info("Starting cron...")
-        self._runners_run_next_jobs_as_event(period_in_mins)
-        logging.info("Cron started!")
+	def start_cron(self, period_in_mins=None):
+		"""
+		CRON job to run next jobs on runners, if applicable. Runs asynchronously.
+		"""
+		if not period_in_mins:
+			period_in_mins = self.frequency_in_mins
+		logging.info("Starting cron...")
+		self._runners_run_next_jobs_as_event(period_in_mins)
+		logging.info("Cron started!")
 
-    def stop_cron(self):
-        """
-        Tell the scheduler to stop scheduling jobs.
-        """
-        logging.info("Stopping cron...")
-        self.event.set()
-        logging.info("Cron stopped!")
+	def stop_cron(self):
+		"""
+		Tell the scheduler to stop scheduling jobs.
+		"""
+		logging.info("Stopping cron...")
+		self.event.set()
+		logging.info("Cron stopped!")
 
-    def reset(self, reset_history=False):
-        """
-        Resets the scheduler.
-        """
-        logging.info("Resetting scheduler...")
-        self.queue = deque()
-        self.processed = []
-        if reset_history:
-            self.history = []
-        self.event = Event()
-        logging.info("Scheduler resetted!")
+	def reset(self, reset_history=False):
+		"""
+		Resets the scheduler.
+		"""
+		logging.info("Resetting scheduler...")
+		self.queue = deque()
+		self.processed = []
+		if reset_history:
+			self.history = []
+		self.event = Event()
+		logging.info("Scheduler resetted!")
 
-    def runners_run_next_jobs(self):
-        """
-        Check each job to see if it has a job running. If not, have the runner
-        run the next job on the queue asynchronously of the others and collect
-        the result of the job that was running before (if applicable).
+	def runners_run_next_jobs(self):
+		"""
+		Check each job to see if it has a job running. If not, have the runner
+		run the next job on the queue asynchronously of the others and collect
+		the result of the job that was running before (if applicable).
 
-        If job that runner is running fails, then put the job back in queue. 
-        If job failed more than num_tries times, don't put the job back in 
-        thw queue.
-        """
-        for i, runner in enumerate(self.runners):
-            # Check if there's any finished jobs and process them.
-            if self.current_jobs[i]:
-                #If the job results are available
-                finished_job_results = self.current_jobs[i].get()
-                if finished_job_results['successful']:
-                    # If the job finished successfully...
-                    self.processed.append(finished_job)
-                    self.history.append(finished_job)
-                    self.current_jobs[i] = None
-                else:
-                    #If some error occurred
-                    job_to_run = self.current_jobs[i]
-                    job_to_run.num_tries_left -= 1
-                    if job_to_run.num_tries_left:
-                        #Still has tries remaining, so put back in queue
-                        self.add_job(job_to_run)
-                    else:
-                        #Record error, ignore failed job
-                        logging.error(finished_job_results['error'])
-                        self.current_jobs[i] = None
+		If job that runner is running fails, then put the job back in queue. 
+		If job failed more than num_tries times, don't put the job back in 
+		thw queue.
+		"""
+		for i, runner in enumerate(self.runners):
+			# Check if there's any finished jobs and process them.
+			if self.current_jobs[i]:
+				#If the job results are available
+				finished_job_results = self.current_jobs[i].get()
+				if finished_job_results['successful']:
+					# If the job finished successfully...
+					self.processed.append(finished_job)
+					self.history.append(finished_job)
+					self.current_jobs[i] = None
+				else:
+					#If some error occurred
+					job_to_run = self.current_jobs[i]
+					job_to_run.num_tries_left -= 1
+					if job_to_run.num_tries_left:
+						#Still has tries remaining, so put back in queue
+						self.add_job(job_to_run)
+					else:
+						#Record error, ignore failed job
+						logging.error(finished_job_results['error'])
+						self.current_jobs[i] = None
 
 
-            # Check if there's any queued jobs and schedule them.
-            if self.queue:
-                # If there's something to be scheduled...
-                job_to_run = self.queue.popleft()
-                job_to_run.num_tries_left = 3
-                # self.current_jobs[i] = runner.run_job(job_to_run)
-                self.current_jobs[i] = self.pool.apply_async(
-                    runner.run_job,
-                    (job_to_run,)
-                )
+			# Check if there's any queued jobs and schedule them.
+			if self.queue:
+				# If there's something to be scheduled...
+				job_to_run = self.queue.popleft()
+				job_to_run.num_tries_left = 3
+				# self.current_jobs[i] = runner.run_job(job_to_run)
+				self.current_jobs[i] = self.pool.apply_async(
+					runner.run_job,
+					(job_to_run,)
+				)
 
-    def _runners_run_next_jobs_as_event(self, period_in_mins):
-        """
-        Trigger above method every period.
-        """
-        logging.info("Running cron job...")
-        self.runners_run_next_jobs()
-        if not self.event.is_set():
-            Timer(
-                period_in_mins * 60,
-                self._runners_run_next_jobs_as_event,
-                [period_in_mins]
-            ).start()
+	def _runners_run_next_jobs_as_event(self, period_in_mins):
+		"""
+		Trigger above method every period.
+		"""
+		logging.info("Running cron job...")
+		self.runners_run_next_jobs()
+		if not self.event.is_set():
+			Timer(
+				period_in_mins * 60,
+				self._runners_run_next_jobs_as_event,
+				[period_in_mins]
+			).start()

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -90,7 +90,7 @@ class DMLScheduler(object):
         the result of the job that was running before (if applicable).
         """
         for i, runner in enumerate(self.runners):
-            # Check if there's any finished jobs and proccess them.
+            # Check if there's any finished jobs and process them.
             if self.current_jobs[i]:
                 # If the job finished...
                 finished_job = self.current_jobs[i].get()

--- a/tests/artifacts/configuration.ini
+++ b/tests/artifacts/configuration.ini
@@ -4,6 +4,7 @@ dataset_path = datasets/mnist
 [SCHEDULER]
 num_runners = 4
 frequency_in_mins = 1
+max_tries = 3
 
 [RUNNER]
 weights_directory = weights

--- a/tests/artifacts/db_client/database_config.json
+++ b/tests/artifacts/db_client/database_config.json
@@ -3,7 +3,7 @@
     "db": "datasharkdb",
     "host": "datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com",
     "port": "5432",
-    "table_name": "test_labels",
+    "table_name": "category_labels_test",
     "num_tries": 3, 
     "wait_time": 10
 }

--- a/tests/test_dmlrunner.py
+++ b/tests/test_dmlrunner.py
@@ -87,7 +87,7 @@ def test_dmlrunner_initialize_job_returns_list_of_nparray(config_manager):
     model_json = make_model_json()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(model_json)
-    initial_weights = runner.run_job(initialize_job)
+    initial_weights = runner.run_job(initialize_job)['return_obj']
     assert type(initial_weights) == list
     assert type(initial_weights[0]) == np.ndarray
 
@@ -98,9 +98,9 @@ def test_dmlrunner_train_job_returns_weights_omega_and_stats(config_manager):
     config = make_config()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(model_json)
-    initial_weights = runner.run_job(initialize_job)
+    initial_weights = runner.run_job(initialize_job)['return_obj']
     train_job = make_train_job(model_json, initial_weights, config, hyperparams)
-    new_weights, omega, train_stats = runner.run_job(train_job)
+    new_weights, omega, train_stats = runner.run_job(train_job)['return_obj']
     assert type(new_weights) == list
     assert type(new_weights[0]) == np.ndarray
     assert type(omega) == int or type(omega) == float
@@ -113,10 +113,10 @@ def test_dmlrunner_validate_job_returns_stats(config_manager):
     config = make_config()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(make_model_json())
-    initial_weights = runner.run_job(initialize_job)
+    initial_weights = runner.run_job(initialize_job)['return_obj']
     train_job = make_train_job(model_json, initial_weights, config, hyperparams)
-    new_weights, omega, train_stats = runner.run_job(train_job)
+    new_weights, omega, train_stats = runner.run_job(train_job)['return_obj']
     hyperparams['split'] = 1 - hyperparams['split']
     validate_job = make_validate_job(model_json, new_weights, config, hyperparams)
-    val_stats = runner.run_job(validate_job)
+    val_stats = runner.run_job(validate_job)['return_obj']
     assert type(val_stats) == dict


### PR DESCRIPTION
_This pull request serves to close #12_

Should be a relatively straightforward pull request.

**Runner:**
- Error or not, `run_job` returns a dictionary called `results` with key `successful`
- If no error has occurred (`successful==True`), then `results` will have a key called `return_obj` with the value being results of the job run (`return_obj` is what was originally returned instead of `results`)
- Added error handling in `run_job`. If an error has occurred (`successful==False`), then `results` will have a key called `error_message` that will hold the actual error that took place when running the job.

**Scheduler:**
- Added error handling + retry logic in `runners_run_next_jobs`. If the job finished unsuccessfully, add it to the end of the queue. If the job finished unsuccessfully more than `max_tries` (currently 3) times, ignore the job and don't add it back to the queue (might need an alternative for this)
- `max_tries` is pulled from the `configuration.ini` 

**Other:**
- Edited `tests/artifacts/configuration.ini` and `questions.csv` to include `max_tries`.
