### PR TITLE
Secret Config

### DIFF
--- a/core/configuration.py
+++ b/core/configuration.py
@@ -12,13 +12,13 @@ class ConfigurationManager(object):
     """
     Configuration Manager
 
-    Singleton class that manages the configuration of all other modules.
+    Class that manages the configuration of all other modules.
 
     """
 
     def __init__(self):
         """
-        Virtually private constructor.
+        Initializes Configuration Manager, config not set up yet
         """
         self.question_format = "{question} [default = {default}] "
         self._config = None
@@ -31,25 +31,27 @@ class ConfigurationManager(object):
         self._config = None
         return self
 
-    def bootstrap(self, config_filepath="core/configuration.ini", input_function=None):
+    def bootstrap(self, config_filepath="core/configuration.ini", 
+                    question_filepath="core/questions.csv", input_function=None):
         """
         Do nothing if config instance already exists. Otherwise, check if
-        core/configuration.ini exists. If not, call run_setup_mode. Then load
+        core/configuration.ini exists. If not, call _run_setup_mode. Then load
         the config instance from configuration.ini
         """
         if self._config:
             return False
         self.input_function = input_function if input_function else input
         self.config_filepath = config_filepath
+        self.question_filepath = question_filepath
         if not os.path.isfile(self.config_filepath):
-            self.run_setup_mode(self.config_filepath, self.input_function)
+            self._run_setup_mode(self.config_filepath, self.question_filepath, self.input_function)
         else:
             self._config = configparser.ConfigParser()
             self._config.read(self.config_filepath)
         return True
 
 
-    def run_setup_mode(self, config_filepath, user_input):
+    def _run_setup_mode(self, config_filepath, question_filepath, user_input):
         """
         Create configuration.ini with the user_input function. In testing,
         this is a deterministic lambda function.
@@ -60,7 +62,7 @@ class ConfigurationManager(object):
         # keep track of corresponding section. Otherwise, ask user question.
         secret_section_message = "; DO NOT MODIFY THIS SECTION\n"
         config = configparser.ConfigParser()
-        rows = [r[1] for r in pd.read_csv("core/questions.csv").iterrows()]
+        rows = [r[1] for r in pd.read_csv(question_filepath).iterrows()]
         secret_sections = set([])
         for row in rows:
             question, section, key, default = row['question'], row['section'], row['key'], row['default']

--- a/core/configuration.py
+++ b/core/configuration.py
@@ -81,7 +81,7 @@ class ConfigurationManager(object):
             lines = f.readlines()
         stripped = [line.strip() for line in lines]
         for secret_section in secret_sections:
-            lines.insert(trimmed.index("[{}]".format(secret_section)), secret_section_message)
+            lines.insert(stripped.index("[{}]".format(secret_section)), secret_section_message)
         with open(config_filepath, "w") as f:
             f.write("".join(lines))
         self._config = config

--- a/core/configuration.py
+++ b/core/configuration.py
@@ -6,73 +6,91 @@ import logging
 
 
 logging.basicConfig(level=logging.DEBUG,
-					format='[ConfigurationManager] %(asctime)s %(levelname)s %(message)s')
+                    format='[ConfigurationManager] %(asctime)s %(levelname)s %(message)s')
 
 class ConfigurationManager(object):
-	"""
-	Configuration Manager
+    """
+    Configuration Manager
 
-	Singleton class that manages the configuration of all other modules.
+    Singleton class that manages the configuration of all other modules.
 
-	"""
+    """
 
-	def __init__(self):
-		"""
-		Virtually private constructor.
-		"""
-		self.question_format = "{question} [default = {default}] "
-		self._config = None
+    def __init__(self):
+        """
+        Virtually private constructor.
+        """
+        self.question_format = "{question} [default = {default}] "
+        self._config = None
 
-	def reset(self):
-		"""
-		Resets the configuration by deleting it. Bootstrap must be called so that
-		the class works as intended.
-		"""
-		self._config = None
-		return self
+    def reset(self):
+        """
+        Resets the configuration by deleting it. Bootstrap must be called so that
+        the class works as intended.
+        """
+        self._config = None
+        return self
 
-	def bootstrap(self, config_filepath="core/configuration.ini", input_function=None):
-		"""
-		Do nothing if config instance already exists. Otherwise, check if
-		core/configuration.ini exists. If not, call run_setup_mode. Then load
-		the config instance from configuration.ini
-		"""
-		if self._config:
-			return False
-		self.input_function = input_function if input_function else input
-		self.config_filepath = config_filepath
-		if not os.path.isfile(self.config_filepath):
-			self.run_setup_mode(self.config_filepath, self.input_function)
-		else:
-			self._config = configparser.ConfigParser()
-			self._config.read(self.config_filepath)
-		return True
-
-
-	def run_setup_mode(self, config_filepath, user_input):
-		"""
-		Create configuration.ini with the user_input function. In testing,
-		this is a deterministic lambda function.
-		Otherwise, the user_input function actually draws upon user input.
-		"""
-		config = configparser.ConfigParser()
-		rows = [r[1] for r in pd.read_csv("core/questions.csv").iterrows()]
-		for row in rows:
-			question, section, key, default = row['question'], row['section'], row['key'], row['default']
-			answer = user_input(self.question_format.format(question=question, default=default))
-			answer = answer if answer else default
-			if not section in config:
-				config[section] = {}
-			config[section][key] = answer
-		with open(self.config_filepath, 'w') as configfile:
-			config.write(configfile)
-		self._config = config
+    def bootstrap(self, config_filepath="core/configuration.ini", input_function=None):
+        """
+        Do nothing if config instance already exists. Otherwise, check if
+        core/configuration.ini exists. If not, call run_setup_mode. Then load
+        the config instance from configuration.ini
+        """
+        if self._config:
+            return False
+        self.input_function = input_function if input_function else input
+        self.config_filepath = config_filepath
+        if not os.path.isfile(self.config_filepath):
+            self.run_setup_mode(self.config_filepath, self.input_function)
+        else:
+            self._config = configparser.ConfigParser()
+            self._config.read(self.config_filepath)
+        return True
 
 
-	def get_config(self):
-		"""
-		Returns the configuration.
-		"""
-		if not self._config:
-			raise Exception("Configuration Manager needs to be bootstrapped first.")
-		return self._config
+    def run_setup_mode(self, config_filepath, user_input):
+        """
+        Create configuration.ini with the user_input function. In testing,
+        this is a deterministic lambda function.
+        Otherwise, the user_input function actually draws upon user input.
+        """
+
+        # Go through each question in questions.csv. If question is SECRET,
+        # keep track of corresponding section. Otherwise, ask user question.
+        secret_section_message = "; DO NOT MODIFY THIS SECTION\n"
+        config = configparser.ConfigParser()
+        rows = [r[1] for r in pd.read_csv("core/questions.csv").iterrows()]
+        secret_sections = set([])
+        for row in rows:
+            question, section, key, default = row['question'], row['section'], row['key'], row['default']
+            if question == 'SECRET':
+                answer = default
+                secret_sections.add(section)
+            else:
+                answer = user_input(self.question_format.format(question=question, default=default))
+                answer = answer if answer else default
+            if section not in config:
+                config[section] = {} 
+            config[section][key] = answer
+        with open(self.config_filepath, 'w') as configfile:
+            config.write(configfile)
+        
+        # For all secret sections, add secret_section_message as a comment.
+        with open(config_filepath, "r") as f:
+            lines = f.readlines()
+        stripped = [line.strip() for line in lines]
+        for secret_section in secret_sections:
+            lines.insert(trimmed.index("[{}]".format(secret_section)), secret_section_message)
+        with open(config_filepath, "w") as f:
+            f.write("".join(lines))
+        self._config = config
+
+
+    def get_config(self):
+        """
+        Returns the configuration.
+        """
+        if not self._config:
+            raise Exception("Configuration Manager needs to be bootstrapped first.")
+        return self._config

--- a/core/db_client.py
+++ b/core/db_client.py
@@ -23,22 +23,25 @@ class DBClient(object):
 
 	TODO: authenthication needs to be set up for DB
 	"""
-	def __init__(self, config_filepath = 'database_config.json'):
+	def __init__(self, config_manager):
 		"""
 		Set up DBClient with corresponding database credentials
 		"""
-
+		config = config_manager._config
 		app = Flask(__name__)
-		with open(config_filepath) as f:
-			db_config = json.load(f)
-		db_config['pw'] = os.environ['DB_PASS']
 		app.config['SQLALCHEMY_DATABASE_URI'] =  \
-			'postgresql://%(user)s:%(pw)s@%(host)s:%(port)s/%(db)s' % db_config
+			'postgresql://{user}:{pw}@{host}:{port}/{db}'.format(
+				user=config.get('DB_CLIENT', 'user'),
+				pw=os.environ['DB_PASS'],
+				host=config.get('DB_CLIENT', 'host'),
+				port=config.getint('DB_CLIENT', 'port'),
+				db=config.get('DB_CLIENT', 'db')
+			)
 		app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 		self.db = SQLAlchemy(app)
-		self.table_name = db_config['table_name']
-		self.num_tries = db_config['num_tries']
-		self.wait_time = db_config['wait_time']
+		self.table_name = config.get('DB_CLIENT', 'table_name')
+		self.num_tries = config.getint('DB_CLIENT', 'max_tries')
+		self.wait_time = config.getint('DB_CLIENT', 'wait_time')
 
 	def _get_labels(self):
 		"""

--- a/core/questions.csv
+++ b/core/questions.csv
@@ -4,3 +4,10 @@ How many runners should the scheduler manage?,SCHEDULER,num_runners,4
 How often should the scheduler run in minutes?,SCHEDULER,frequency_in_mins,1
 Where is the weights directory?,RUNNER,weights_directory,weights
 What is the max number of times a job should run?,SCHEDULER,max_tries,3
+SECRET,DB_CLIENT,user,datashark
+SECRET,DB_CLIENT,db,datasharkdb
+SECRET,DB_CLIENT,host,datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com
+SECRET,DB_CLIENT,port,5432
+SECRET,DB_CLIENT,table_name,category_labels
+SECRET,DB_CLIENT,max_tries,3
+SECRET,DB_CLIENT,wait_time,10

--- a/tests/artifacts/config_manager/questions.csv
+++ b/tests/artifacts/config_manager/questions.csv
@@ -1,0 +1,20 @@
+question,section,key,default
+Where is the dataset path?,GENERAL,dataset_path,datasets/mnist
+How many runners should the scheduler manage?,SCHEDULER,num_runners,4
+How often should the scheduler run in minutes?,SCHEDULER,frequency_in_mins,1
+Where is the weights directory?,RUNNER,weights_directory,weights
+What is the max number of times a job should run?,SCHEDULER,max_tries,3
+SECRET,DB_CLIENT,user,datashark
+SECRET,DB_CLIENT,db,datasharkdb
+SECRET,DB_CLIENT,host,datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com
+SECRET,DB_CLIENT,port,5432
+SECRET,DB_CLIENT,table_name,category_labels
+SECRET,DB_CLIENT,max_tries,3
+SECRET,DB_CLIENT,wait_time,10
+SECRET,DB_CLIENT_2,user,datashark
+SECRET,DB_CLIENT_2,db,datasharkdb
+SECRET,DB_CLIENT_2,host,datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com
+SECRET,DB_CLIENT_2,port,5432
+SECRET,DB_CLIENT_2,table_name,category_labels
+SECRET,DB_CLIENT_2,max_tries,3
+SECRET,DB_CLIENT_2,wait_time,10

--- a/tests/artifacts/db_client/configuration.ini
+++ b/tests/artifacts/db_client/configuration.ini
@@ -1,0 +1,21 @@
+[GENERAL]
+dataset_path = datasets/mnist
+
+[SCHEDULER]
+num_runners = 4
+frequency_in_mins = 1
+max_tries = 3
+
+[RUNNER]
+weights_directory = weights
+
+; DO NOT MODIFY THIS SECTION
+[DB_CLIENT]
+user = datashark
+db = datasharkdb
+host = datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com
+port = 5432
+table_name = category_labels
+max_tries = 3
+wait_time = 10
+

--- a/tests/artifacts/db_client/database_config.json
+++ b/tests/artifacts/db_client/database_config.json
@@ -1,9 +1,0 @@
-{
-    "user": "datashark",
-    "db": "datasharkdb",
-    "host": "datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com",
-    "port": "5432",
-    "table_name": "clt",
-    "num_tries": 3, 
-    "wait_time": 10
-}

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -41,7 +41,7 @@ def setup_default_worked(cm):
     assert config.get('DB_CLIENT', 'user') == 'datashark'
     assert config.get('DB_CLIENT', 'db') == 'datasharkdb'
     assert config.get('DB_CLIENT', 'host') == 'datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com'
-    assert config.get('DB_CLIENT', 'port') == '5432'
+    assert config.getint('DB_CLIENT', 'port') == 5432
     assert config.get('DB_CLIENT', 'table_name') == 'category_labels'
     assert config.getint('DB_CLIENT', 'max_tries') == 3
     assert config.getint('DB_CLIENT', 'wait_time') == 10

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -8,65 +8,95 @@ from core.configuration import ConfigurationManager
 
 
 if not os.path.isdir('tests/artifacts/config_manager'):
-	os.mkdir('tests/artifacts/config_manager')
-
+    os.mkdir('tests/artifacts/config_manager')
 
 def check_config_exists(cm):
-	""" Ensure that a config file was created using default user input. """
-	assert cm.get_config()
+    """
+    Ensure that a config file was created using default user input.
+    """
+    assert cm.get_config()
 
+def comments_test(config_filepath):
+    """
+    Check that comments were added to secret sections
+    """
+    secret_sections = ['DB_CLIENT']
+    secret_section_message = "; DO NOT MODIFY THIS SECTION"
+    with open(config_filepath, "r") as f:
+        lines = [line.strip() for line in f.readlines()]
+        for secret_section in secret_sections:
+            assert lines[lines.index("[{}]".format(secret_section)) - 1] == secret_section_message
 
 def setup_default_worked(cm):
-	""" Actually verify that the config file created using default user input is correct. """
-	config = cm.get_config()
-	assert config.get('GENERAL', 'dataset_path') == 'datasets/mnist'
-	assert config.getint('SCHEDULER', 'num_runners') == 4
-	assert config.getint('SCHEDULER', 'frequency_in_mins') == 1
-	assert config.get('RUNNER', 'weights_directory') == 'weights'
-
+    """
+    Actually verify that the config file created using default user input is correct.
+    
+    Also verify that secret sections have their assigned values.
+    """
+    config = cm.get_config()
+    assert config.get('GENERAL', 'dataset_path') == 'datasets/mnist'
+    assert config.getint('SCHEDULER', 'num_runners') == 4
+    assert config.getint('SCHEDULER', 'frequency_in_mins') == 1
+    assert config.get('RUNNER', 'weights_directory') == 'weights'
+    assert config.get('DB_CLIENT', 'user') == 'datashark'
+    assert config.get('DB_CLIENT', 'db') == 'datasharkdb'
+    assert config.get('DB_CLIENT', 'host') == 'datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com'
+    assert config.get('DB_CLIENT', 'port') == '5432'
+    assert config.get('DB_CLIENT', 'table_name') == 'category_labels'
+    assert config.getint('DB_CLIENT', 'max_tries') == 3
+    assert config.getint('DB_CLIENT', 'wait_time') == 10
 
 def setup_custom_worked(cm, custom_string):
-	""" Actually verify that the config file created using custom user input is correct. """
-	config = cm.get_config()
-	assert config.get('GENERAL', 'dataset_path') == custom_string
-	assert config.get('SCHEDULER', 'num_runners') == custom_string
-	assert config.get('SCHEDULER', 'frequency_in_mins') == custom_string
-	assert config.get('RUNNER', 'weights_directory') == custom_string
+    """
+    Actually verify that the config file created using custom user input is correct.
+    
+    Also verify that values in secret sections aren't custom_string
+    """
+    config = cm.get_config()
+    assert config.get('GENERAL', 'dataset_path') == custom_string
+    assert config.get('SCHEDULER', 'num_runners') == custom_string
+    assert config.get('SCHEDULER', 'frequency_in_mins') == custom_string
+    assert config.get('RUNNER', 'weights_directory') == custom_string
+    assert all([item != custom_string for item in list(cm._config.items('DB_CLIENT'))])
 
 def test_complete_setup_default():
-	""" Verify configuration.ini from default user input is created and correct. """
-	config_manager = ConfigurationManager()
-	config_manager.bootstrap(
-		config_filepath='tests/artifacts/config_manager/configuration.ini',
-		input_function=lambda x: ''
-	)
-	check_config_exists(config_manager)
-	setup_default_worked(config_manager)
-	os.remove(config_manager.config_filepath)
+    """
+    Verify configuration.ini from default user input is created and correct.
+    """
+    config_manager = ConfigurationManager()
+    config_manager.bootstrap(
+        config_filepath='tests/artifacts/config_manager/configuration.ini',
+        input_function=lambda x: ''
+    )
+    check_config_exists(config_manager)
+    setup_default_worked(config_manager)
+    comments_test('tests/artifacts/config_manager/configuration.ini')
+    os.remove(config_manager.config_filepath)
 
 
 def test_complete_setup_custom():
-	""" Verify configuration.ini from custom user input is created and correct. """
-	config_manager = ConfigurationManager()
-	custom_string = 'test'
-	config_manager.bootstrap(
-		config_filepath='tests/artifacts/config_manager/configuration2.ini',
-		input_function=lambda x: custom_string
-	)
-	check_config_exists(config_manager)
-	setup_custom_worked(config_manager, custom_string)
-	os.remove(config_manager.config_filepath)
+    """ Verify configuration.ini from custom user input is created and correct. """
+    config_manager = ConfigurationManager()
+    custom_string = 'test'
+    config_manager.bootstrap(
+        config_filepath='tests/artifacts/config_manager/configuration2.ini',
+        input_function=lambda x: custom_string
+    )
+    check_config_exists(config_manager)
+    setup_custom_worked(config_manager, custom_string)
+    comments_test('tests/artifacts/config_manager/configuration2.ini')
+    os.remove(config_manager.config_filepath)
 
 
 def test_no_setup_repeat():
-	""" Verify that run_setup_mode is not run again when configuration already exists. Or more simply, that the
-		configuration has not changed) """
-	config_manager = ConfigurationManager()
-	config_manager.bootstrap(
-		config_filepath='tests/artifacts/config_manager/configuration3.ini',
-		input_function=lambda x: ''
-	)
-	check_config_exists(config_manager)
-	assert not config_manager.bootstrap()
-	setup_default_worked(config_manager)
-	os.remove(config_manager.config_filepath)
+    """ Verify that run_setup_mode is not run again when configuration already exists. Or more simply, that the
+        configuration has not changed) """
+    config_manager = ConfigurationManager()
+    config_manager.bootstrap(
+        config_filepath='tests/artifacts/config_manager/configuration3.ini',
+        input_function=lambda x: ''
+    )
+    check_config_exists(config_manager)
+    assert not config_manager.bootstrap()
+    setup_default_worked(config_manager)
+    os.remove(config_manager.config_filepath)

--- a/tests/test_configuration_manager.py
+++ b/tests/test_configuration_manager.py
@@ -50,14 +50,20 @@ def setup_custom_worked(cm, custom_string):
     """
     Actually verify that the config file created using custom user input is correct.
     
-    Also verify that values in secret sections aren't custom_string
+    Also verify that values in secret sections still have assigned values
     """
     config = cm.get_config()
     assert config.get('GENERAL', 'dataset_path') == custom_string
     assert config.get('SCHEDULER', 'num_runners') == custom_string
     assert config.get('SCHEDULER', 'frequency_in_mins') == custom_string
     assert config.get('RUNNER', 'weights_directory') == custom_string
-    assert all([item != custom_string for item in list(cm._config.items('DB_CLIENT'))])
+    assert config.get('DB_CLIENT', 'user') == 'datashark'
+    assert config.get('DB_CLIENT', 'db') == 'datasharkdb'
+    assert config.get('DB_CLIENT', 'host') == 'datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com'
+    assert config.get('DB_CLIENT', 'port') == '5432'
+    assert config.get('DB_CLIENT', 'table_name') == 'category_labels'
+    assert config.getint('DB_CLIENT', 'max_tries') == 3
+    assert config.getint('DB_CLIENT', 'wait_time') == 10
 
 def test_complete_setup_default():
     """
@@ -75,7 +81,9 @@ def test_complete_setup_default():
 
 
 def test_complete_setup_custom():
-    """ Verify configuration.ini from custom user input is created and correct. """
+    """
+    Verify configuration.ini from custom user input is created and correct.
+    """
     config_manager = ConfigurationManager()
     custom_string = 'test'
     config_manager.bootstrap(
@@ -89,8 +97,10 @@ def test_complete_setup_custom():
 
 
 def test_no_setup_repeat():
-    """ Verify that run_setup_mode is not run again when configuration already exists. Or more simply, that the
-        configuration has not changed) """
+    """
+    Verify that run_setup_mode is not run again when configuration already
+    exists. Or more simply, that the configuration has not changed) 
+    """
     config_manager = ConfigurationManager()
     config_manager.bootstrap(
         config_filepath='tests/artifacts/config_manager/configuration3.ini',

--- a/tests/test_dbclient.py
+++ b/tests/test_dbclient.py
@@ -6,15 +6,19 @@ import pandas as pd
 import string
 import random
 from core.db_client import DBClient
+from core.configuration import ConfigurationManager
+
 
 @pytest.fixture
 def db_client():
     """
     Maintain instance of DB Client
     """
-    return DBClient(
-        config_filepath='tests/artifacts/db_client/database_config.json'
+    config_manager = ConfigurationManager()
+    config_manager.bootstrap(
+        config_filepath='tests/artifacts/db_client/configuration.ini'
     )
+    return DBClient(config_manager)
 
 def check_empty_category_labels(db_client):
     """


### PR DESCRIPTION
For sake of ease, define _secret sections_ as config sections that the user should not touch. Meaning, the user should not touch any entry in the section. Based on the modules we have, I assumed that sections were either entirely secret or entirely customizable (i.e. Scheduler is customizable, DBClient is secret). If this doesn't hold true, I can easily switch to commenting on each entry that the user shouldn't touch (although it would look a lot more messy).

Major changes:
- DBClient now uses Configuration Manager and pulls from `configuration.ini` to get its necessary configurations. I uncommented and ran its tests as a sanity check that it still works.
- For configurations that belong in a secret section, the corresponding entry for `question` is `SECRET`
- The Configuration Manager then filters entries in `questions.csv` based on whether the value of question is `SECRET` or not. If the value is `SECRET`, then don't ask the user a question and just fill out the entry in the secret section using the default value. If not, the behavior is the same as before.
- Throughout this, the Configuration Manager keeps track of what the secret sections are. After the `configuration.ini` is created, the Configuration Manager then adds comments above secret sections to show they should not be touched.
- Tests are also updated to test that values in secret sections are not affected by user input (i.e. they remain as the "default" values)

This is what secret sections would look like now:
```
; DO NOT MODIFY THIS SECTION
[DB_CLIENT]
user = datashark
db = datasharkdb
host = datasharkdatabase.cwnzqu4zi2kl.us-west-1.rds.amazonaws.com
port = 5432
table_name = category_labels
max_tries = 3
wait_time = 10
```
