### PR TITLE
Add DMLResult and incorporate it to the Runner->Scheduler error flow

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -44,6 +44,7 @@ class DMLScheduler(object):
 		self.pool = Pool(processes=self.num_runners)
 		self.runners = [DMLRunner(config_manager) for _ in range(self.num_runners)]
 		self.current_jobs = [None for _ in range(self.num_runners)]
+		self.current_results = [None for _ in range(self.num_runners)]
 		logging.info("Scheduler is set up!")
 
 	def add_job(self, dml_job):
@@ -96,27 +97,27 @@ class DMLScheduler(object):
 		"""
 		for i, runner in enumerate(self.runners):
 			# Check if there's any finished jobs and process them.
-			if self.current_jobs[i]:
+			if self.current_results[i]:
 				#If the job results are available
-				finished_job_results = self.current_jobs[i].get()
-				if finished_job_results['successful']:
+				finished_results = self.current_results[i].get()
+				if finished_results.status == 'successful':
 					# If the job finished successfully...
-					finished_job = finished_job_results['return_obj']
-					self.processed.append(finished_job)
-					self.history.append(finished_job)
+					self.processed.append(finished_results)
+					self.history.append(finished_results)
 					self.current_jobs[i] = None
-				else:
-					#If some error occurred
+					self.current_results[i] = None
+				elif finished_results.status == 'failed':
+					# If some error occurred
 					job_to_run = self.current_jobs[i]
 					job_to_run.num_tries_left -= 1
-					if job_to_run.num_tries_left:
-						#Still has tries remaining, so put back in queue
+					if job_to_run.num_tries_left > 0:
+						# Still has tries remaining, so put back in queue
 						self.add_job(job_to_run)
 					else:
-						#Log error, ignore failed job
-						logging.error(finished_job_results['error'])
+						# Log error, ignore failed job
+						logging.error(finished_results.error_message)
 						self.current_jobs[i] = None
-
+						self.current_results[i] = None
 
 			# Check if there's any queued jobs and schedule them.
 			if self.queue:
@@ -124,7 +125,8 @@ class DMLScheduler(object):
 				job_to_run = self.queue.popleft()
 				job_to_run.num_tries_left = self.max_tries
 				# self.current_jobs[i] = runner.run_job(job_to_run)
-				self.current_jobs[i] = self.pool.apply_async(
+				self.current_jobs[i] = job_to_run
+				self.current_results[i] = self.pool.apply_async(
 					runner.run_job,
 					(job_to_run,)
 				)

--- a/core/utils/dmljob.py
+++ b/core/utils/dmljob.py
@@ -24,9 +24,9 @@ class DMLJob(object):
         Initializes a DML Result object.
 
         Args:
-            job_type (string): the job type.
+            job_type (str): the job type.
             serialized_model (dict): the model to train in a serialized format.
-            framework_type (string): the type of framework the model is in [keras].
+            framework_type (str): the type of framework the model is in [keras].
             weights (list): list of np.arrays representing the weghts of a model.
             hyperparams (dict): hyperparameters for training/validating a model.
             label_index (int): index that represents which column of the

--- a/core/utils/dmlresult.py
+++ b/core/utils/dmlresult.py
@@ -1,0 +1,68 @@
+from core.utils.dmljob import serialize_job, deserialize_job
+
+class DMLResult(object):
+    """
+    DML Result
+
+    This class is created by the Runners whenever they're done running a job,
+    and it's passed to the Communication Manager on success or back to the
+    Scheduler on error.
+
+    """
+
+    def __init__(
+        self,
+        status,
+        job,
+        results={},
+        error_message="",
+    ):
+        """
+        Initializes a DML Result object.
+
+        Args:
+            status (str): status of the job [successful|failed].
+            job (DMLJob): job that finished running.
+            results (dict): results from running the job.
+            error_message (str): error message of why the job failed (if it did).
+        """
+        self.status = status
+        self.job = job
+        self.results = results
+        self.error_message = error_message
+
+
+def serialize_result(dmlresult_job):
+    """
+    Serializes a DML Result object into a dictionary.
+
+    Args:
+        dmlresult_job (DMLResult): result object.
+
+    Returns:
+        dict: The serialized version of the DML Result.
+    """
+    return {
+        'status': dmlresult_job.status,
+        'job': serialize_job(dmlresult_job.job),
+        'results': dmlresult_job.results,
+        'error_message': dmlresult_job.error_message,
+    }
+
+
+def deserialize_result(serialized_result):
+    """
+    Deserializes a serialized version of a DML Result object.
+
+    Args:
+        serialized_result (dict): serialized version of a DML Result object.
+
+    Returns:
+        DMLResult: A DML Result object from serialized_result.
+    """
+    return DMLResult(
+        status=serialized_result['status'],
+        job=deserialize_job(serialized_result['job']),
+        results=serialized_result['results'],
+        error_message=serialized_result['error_message'],
+    )

--- a/core/utils/dmlresult.py
+++ b/core/utils/dmlresult.py
@@ -8,12 +8,15 @@ class DMLResult(object):
     and it's passed to the Communication Manager on success or back to the
     Scheduler on error.
 
+    TODO: Right now the DMLResult object is passing around the DMLJob that
+    originated the results, but we can do better.
+
     """
 
     def __init__(
         self,
         status,
-        job,
+        job_type,
         results={},
         error_message="",
     ):
@@ -22,12 +25,12 @@ class DMLResult(object):
 
         Args:
             status (str): status of the job [successful|failed].
-            job (DMLJob): job that finished running.
+            job_type (str): job type of the job that finished running.
             results (dict): results from running the job.
             error_message (str): error message of why the job failed (if it did).
         """
         self.status = status
-        self.job = job
+        self.job_type = job_type
         self.results = results
         self.error_message = error_message
 
@@ -44,7 +47,7 @@ def serialize_result(dmlresult_job):
     """
     return {
         'status': dmlresult_job.status,
-        'job': serialize_job(dmlresult_job.job),
+        'job_type': dmlresult_job.job_type,
         'results': dmlresult_job.results,
         'error_message': dmlresult_job.error_message,
     }
@@ -62,7 +65,7 @@ def deserialize_result(serialized_result):
     """
     return DMLResult(
         status=serialized_result['status'],
-        job=deserialize_job(serialized_result['job']),
+        job_type=serialized_result['job_type'],
         results=serialized_result['results'],
         error_message=serialized_result['error_message'],
     )

--- a/models/keras_perceptron.py
+++ b/models/keras_perceptron.py
@@ -29,7 +29,7 @@ class KerasPerceptron(GenericKerasModel):
         model.add(Dense(self.n_hidden1, input_shape=(self.n_input,), activation='relu'))
         model.add(Dense(self.n_hidden2, activation='relu'))
         model.add(Dense(self.n_classes, activation='linear'))
-        model.summary()
+        # model.summary()
         return model
 
     def compile_model(self):

--- a/tests/test_dmlrunner.py
+++ b/tests/test_dmlrunner.py
@@ -81,7 +81,7 @@ def test_dmlrunner_initialize_job_returns_list_of_nparray(config_manager):
     model_json = make_model_json()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(model_json)
-    initial_weights = runner.run_job(initialize_job)['return_obj']
+    initial_weights = runner.run_job(initialize_job).results['initial_weights']
     assert type(initial_weights) == list
     assert type(initial_weights[0]) == np.ndarray
 
@@ -91,9 +91,12 @@ def test_dmlrunner_train_job_returns_weights_omega_and_stats(config_manager):
     hyperparams = make_hyperparams()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(model_json)
-    initial_weights = runner.run_job(initialize_job)['return_obj']
+    initial_weights = runner.run_job(initialize_job).results['initial_weights']
     train_job = make_train_job(model_json, initial_weights, hyperparams)
-    new_weights, omega, train_stats = runner.run_job(train_job)['return_obj']
+    results = runner.run_job(train_job).results
+    new_weights = results['new_weights']
+    omega = results['omega']
+    train_stats = results['train_stats']
     assert type(new_weights) == list
     assert type(new_weights[0]) == np.ndarray
     assert type(omega) == int or type(omega) == float
@@ -105,10 +108,13 @@ def test_dmlrunner_validate_job_returns_stats(config_manager):
     hyperparams = make_hyperparams()
     runner = DMLRunner(config_manager)
     initialize_job = make_initialize_job(make_model_json())
-    initial_weights = runner.run_job(initialize_job)['return_obj']
+    initial_weights = runner.run_job(initialize_job).results['initial_weights']
     train_job = make_train_job(model_json, initial_weights, hyperparams)
-    new_weights, omega, train_stats = runner.run_job(train_job)['return_obj']
+    results = runner.run_job(train_job).results
+    new_weights = results['new_weights']
+    omega = results['omega']
+    train_stats = results['train_stats']
     hyperparams['split'] = 1 - hyperparams['split']
     validate_job = make_validate_job(model_json, new_weights, hyperparams)
-    val_stats = runner.run_job(validate_job)['return_obj']
+    val_stats = runner.run_job(validate_job).results['val_stats']
     assert type(val_stats) == dict

--- a/tests/test_dmlscheduler.py
+++ b/tests/test_dmlscheduler.py
@@ -51,7 +51,8 @@ def test_dmlscheduler_sanity():
     while not scheduler.processed:
         time.sleep(0.1)
         scheduler.runners_run_next_jobs()
-    initial_weights = scheduler.processed.pop(0)
+    output = scheduler.processed.pop(0)
+    initial_weights = output.results['initial_weights']
     assert type(initial_weights) == list
     assert type(initial_weights[0]) == np.ndarray
 
@@ -80,7 +81,8 @@ def test_dmlscheduler_arbitrary_scheduling():
         scheduler.runners_run_next_jobs()
     assert len(scheduler.processed) == 5
     while scheduler.processed:
-        initial_weights = scheduler.processed.pop(0)
+        output = scheduler.processed.pop(0)
+        initial_weights = output.results['initial_weights']
         assert type(initial_weights) == list
         assert type(initial_weights[0]) == np.ndarray
 
@@ -100,6 +102,7 @@ def test_dmlscheduler_cron():
     scheduler.stop_cron()
     assert len(scheduler.processed) == 3
     while scheduler.processed:
-        initial_weights = scheduler.processed.pop(0)
+        output = scheduler.processed.pop(0)
+        initial_weights = output.results['initial_weights']
         assert type(initial_weights) == list
         assert type(initial_weights[0]) == np.ndarray


### PR DESCRIPTION
This PR introduces a DMLResult class. DMLResult objects are created inside the Runners once a DMLJob is executed. A DMLResult contains metadata of the job (status, error message, job type) as well as the results of the job.

This PR also makes the Runners return the DMLResults to the Scheduler, which ignores them if the jobs were successful or does retry-logic if the jobs failed. As a side note, the Scheduler's retry-logic seemed to have a bug and as an attempt to fix it I broke up the `current_jobs` property into two lists: one for DMLJob objects and another for asynchronous DMLResult objects (asynchronous because these are promise objects from Python's pool library).

The next PR will incorporate the DMLResult class to the Communication Manager for the success flow of a job.