### PR TITLE
Uniform Initialization of Models from Seed

### DIFF
--- a/models/keras_perceptron.py
+++ b/models/keras_perceptron.py
@@ -26,9 +26,9 @@ class KerasPerceptron(GenericKerasModel):
 
     def build_model(self):
         model = Sequential()
-        model.add(Dense(self.n_hidden1, input_shape=(self.n_input,), activation='relu'))
-        model.add(Dense(self.n_hidden2, activation='relu'))
-        model.add(Dense(self.n_classes, activation='linear'))
+        model.add(Dense(self.n_hidden1, input_shape=(self.n_input,), activation='relu', kernel_initializer=keras.initializers.glorot_uniform(seed=14)))
+        model.add(Dense(self.n_hidden2, activation='relu', kernel_initializer=keras.initializers.glorot_uniform(seed=15)))
+        model.add(Dense(self.n_classes, activation='linear', kernel_initializer=keras.initializers.glorot_uniform(seed=16)))
         # model.summary()
         return model
 

--- a/tests/test_dmlrunner.py
+++ b/tests/test_dmlrunner.py
@@ -90,6 +90,16 @@ def train_dmlresult_obj(config_manager, split_dmlresult_obj, init_dmlresult_obj,
                 )
     result = runner.run_job(train_job)
     return result
+def test_dmlrunner_uniform_initialization(config_manager, ipfs_client):
+    runner = DMLRunner(config_manager)
+    runner.configure(ipfs_client)
+    initialize_job = make_initialize_job(make_model_json(), small_filepath)
+    result = runner.run_job(initialize_job).results
+    first_weights = result['weights']
+    initialize_job = make_initialize_job(make_model_json(), small_filepath)
+    result = runner.run_job(initialize_job).results
+    second_weights = result['weights']
+    assert all(np.allclose(arr1, arr2) for arr1,arr2 in zip(first_weights, second_weights))
 
 def test_dmlrunner_communicate_job(config_manager, train_dmlresult_obj, ipfs_client):
     runner = DMLRunner(config_manager)


### PR DESCRIPTION
By compiling layers of the Keras model with the seed argument set for the glorot_uniform initializer, we can ensure that models are initialized with the same weights. If we choose to have a bias initializer, then we would similarly set the seed for the bias initializer, but the bias is initialized to all zeros by default.

Although this capability is inherent in the Unix Service, and this PR just adds a test to ensure it stays that way, we need to make sure in Explora that we either urge developers to add the seed when they create their Model, or do it for them.